### PR TITLE
display localization correctly during server play.

### DIFF
--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/ChestInfoTools.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/ChestInfoTools.java
@@ -78,7 +78,7 @@ public class ChestInfoTools {
     }
 
     private static void showChestContents(@Nonnull IProbeInfo probeInfo, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull List<ItemStack> stacks, boolean detailed) {
-        IProbeInfo vertical = probeInfo.vertical(probeInfo.defaultLayoutStyle().borderColor(ConfigSetup.chestContentsBorderColor).spacing(0));;
+        IProbeInfo vertical = probeInfo.vertical(probeInfo.defaultLayoutStyle().borderColor(ConfigSetup.chestContentsBorderColor).spacing(0));
         IProbeInfo horizontal = null;
 
         int rows = 0;
@@ -88,7 +88,8 @@ public class ChestInfoTools {
             for (ItemStack stackInSlot : stacks) {
                 vertical.horizontal(new LayoutStyle().spacing(5).alignment(ElementAlignment.ALIGN_CENTER))
                         .item(stackInSlot, new ItemStyle().width(20).height(20))
-                        .text(INFO + stackInSlot.getDisplayName() + " ");
+                        .itemLabel(stackInSlot)
+                        .text(INFO + " ");
             }
         } else {
             for (ItemStack stackInSlot : stacks) {

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
@@ -166,7 +166,7 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
 
     private void addFluidInfo(@Nonnull IProbeInfo probeInfo, @Nonnull ProbeConfig config, @Nullable FluidStack fluidStack, int maxContents) {
         if (fluidStack != null)
-            probeInfo.text(NAME + "{*theoneprobe.provider.block.fluid*} " + fluidStack.getLocalizedName());
+            probeInfo.text(NAME + "{*theoneprobe.provider.block.fluid*} " + " {*" + fluidStack.getUnlocalizedName() +"*}");
         int contents = fluidStack == null ? 0 : fluidStack.amount;
 
         if (config.getTankMode() == 1) {


### PR DESCRIPTION
This pr contains fixes that allow players to see the localization of ChestContents and fluids when they play the server.